### PR TITLE
Fix missing map references for legacy code

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,13 +78,22 @@ function initMap() {
             }
         });
 
+        // Expose core instances for legacy scripts
+        window.map = globals.map;
+        window.currentDay = globals.currentDay;
+        window.currentRoutes = globals.currentRoutes;
+        window.routePolygons = globals.routePolygons;
+
         // Initialize services with error handling
         try {
             globals.geocoder = new google.maps.Geocoder();
-            globals.infoWindow = new google.maps.InfoWindow({ 
+            globals.infoWindow = new google.maps.InfoWindow({
                 maxWidth: 300,
                 pixelOffset: new google.maps.Size(0, -30)
             });
+            // Make services available to older code
+            window.geocoder = globals.geocoder;
+            window.infoWindow = globals.infoWindow;
         } catch (error) {
             console.error("Failed to initialize Google Maps services:", error);
             showToast('error', 'Failed to initialize map services');
@@ -175,6 +184,9 @@ function initDrawingManager() {
     });
 
     globals.drawingManager.setMap(globals.map);
+
+    // Share drawing manager with legacy scripts
+    window.drawingManager = globals.drawingManager;
 
     // Add polygon completion listener with error handling
     google.maps.event.addListener(globals.drawingManager, 'polygoncomplete', (polygon) => {

--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
 </head>
 <body class="light-mode">
     <!-- Loading screen -->


### PR DESCRIPTION
## Summary
- sync Google Maps instances created in app.js with global variables used by legacy routes.js
- expose geocoder, infoWindow and drawingManager to old code
- remove duplicate animate.css link in index

## Testing
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_683fb5b3af6483238797aafcbf5a5d6f