### PR TITLE
Fix Google map failing to load

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,6 +41,14 @@ window.addEventListener('DOMContentLoaded', () => {
             loadingScreen.style.visibility = 'hidden';
         }
     }, 2000);
+
+    // Detect Google Maps loading issues
+    const mapsScript = document.getElementById('googleMapsScript');
+    if (mapsScript) {
+        mapsScript.addEventListener('error', () => {
+            showErrorDialog('Failed to load Google Maps. Please check your internet connection or API key.');
+        });
+    }
 });
 
 // Initialize Google Map

--- a/index.html
+++ b/index.html
@@ -154,6 +154,6 @@
     <!-- All scripts at the end of the body in correct order -->
     <script src="routes.js"></script>
     <script src="app.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyD6dMrmfhOuABbU3_0zspACG_CO_VjIgxo&callback=initMap&libraries=drawing,places,geometry"></script>
+    <script id="googleMapsScript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyD6dMrmfhOuABbU3_0zspACG_CO_VjIgxo&callback=initMap&libraries=drawing,places,geometry" async defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add async loading attributes for Google Maps script
- display a user-friendly error if the Google Maps API fails to load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fbe9d33f483239048090731793f3d