### PR TITLE
Add Mapbox token to config

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,2 @@
+// Rename to config.js and fill in your Mapbox token
+window.MAPBOX_TOKEN = 'pk.eyJ1IjoicmVwb3NlZCIsImEiOiJjbWN3b2tpcjAwMzJ4MmtwdnRrNWJ2bGU1In0.pbthQ_soCYTCN6FMdIvZGw';


### PR DESCRIPTION
## Summary
- include `config.js` with provided Mapbox token so the map loads immediately

## Testing
- `grep -n config.js index.html`

------
https://chatgpt.com/codex/tasks/task_e_6884b94454b8832393dd13d65e52badc