### PR TITLE
Enable WorkWave order import with route colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,7 @@
                         <div class="button-group">
                             <button id="exportRoutes" class="action-btn"><i class="fas fa-download"></i> Export Routes</button>
                             <button id="importRoutes" class="action-btn"><i class="fas fa-upload"></i> Import Routes</button>
+                            <button id="importWorkwave" class="action-btn"><i class="fas fa-file-import"></i> Import WorkWave Orders</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Allow admins to import WorkWave CSV files and show each order as a colored dot
- Assign colors per route and reset color mapping on each import
- Expose new "Import WorkWave Orders" button in admin panel

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896570f37208323b38fd94b4278a5c9