### PR TITLE
feat: add React day selector

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: 'CodeQL'
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/index.html
+++ b/index.html
@@ -36,18 +36,7 @@
                 <h1>Meal Map</h1>
             </div>
             <div class="controls">
-                <div class="day-selector">
-                    <label for="daySelect">Day:</label>
-                    <select id="daySelect">
-                        <option value="monday">Monday</option>
-                        <option value="tuesday">Tuesday</option>
-                        <option value="wednesday">Wednesday</option>
-                        <option value="thursday">Thursday</option>
-                        <option value="friday">Friday</option>
-                        <option value="saturday">Saturday</option>
-                        <option value="sunday">Sunday</option>
-                    </select>
-                </div>
+                <div id="day-selector-root" class="day-selector"></div>
                 <div class="toggle-container">
                     <label class="toggle-switch">
                         <input type="checkbox" id="darkModeToggle">
@@ -190,6 +179,10 @@
     <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.4.1/mapbox-gl-draw.js"></script>
     <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v5.0.0/mapbox-gl-geocoder.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@turf/turf@6/turf.min.js"></script>
+    <!-- React dependencies -->
+    <script crossorigin defer src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+    <script crossorigin defer src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+    <script defer src="src/js/react/day-selector.js"></script>
     <script src="config.js"></script>
     <script src="src/js/routes.js"></script>
     <script src="src/js/mapbox.js"></script>

--- a/src/js/react/day-selector.js
+++ b/src/js/react/day-selector.js
@@ -1,0 +1,25 @@
+/* global React, ReactDOM */
+
+const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+
+function DaySelector() {
+    return React.createElement(
+        React.Fragment,
+        null,
+        React.createElement('label', { htmlFor: 'daySelect' }, 'Day:'),
+        React.createElement(
+            'select',
+            { id: 'daySelect', defaultValue: 'monday' },
+            days.map((day) => React.createElement(
+                'option',
+                { value: day, key: day },
+                day.charAt(0).toUpperCase() + day.slice(1),
+            )),
+        ),
+    );
+}
+
+const container = document.getElementById('day-selector-root');
+if (container) {
+    ReactDOM.render(React.createElement(DaySelector), container);
+}


### PR DESCRIPTION
## Summary
- replace static day dropdown with React component
- include React dependencies to start framework migration
- run CodeQL on JS with dedicated workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68973080d59c8323b4151a37d8d7e6c5