### PR TITLE
chore: remove unused admin bundle reference

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,7 @@ module.exports = (env, argv) => {
   
   return {
     entry: {
-      main: './src/js/main.js',
-      admin: './src/js/admin.js'
+      main: './src/js/main.js'
     },
     output: {
       path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
## Summary
- drop admin.js entry from webpack config since file no longer exists

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Can't resolve './features/admin-panel', './features/export-manager', './features/import-manager')*

------
https://chatgpt.com/codex/tasks/task_e_68973681409c832397fc8a82f8c20875