### PR TITLE
chore: remove unused admin bundle reference

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -7,7 +7,6 @@
 // Import CSS
 import '../css/style.css';
 import '../css/user_interface.css';
-import '../css/admin-panel.css';
 
 // Import utility modules
 import './utils/html-sanitizer';
@@ -20,9 +19,6 @@ import './core/ui-manager';
 
 // Import feature modules
 import './features/route-manager';
-import './features/admin-panel';
-import './features/export-manager';
-import './features/import-manager';
 
 /**
  * Initialize the application when the DOM is fully loaded
@@ -63,11 +59,6 @@ function initApp() {
             // Initialize route manager
             if (window.MealMap.routeManager && typeof window.MealMap.routeManager.init === 'function') {
               window.MealMap.routeManager.init();
-            }
-            
-            // Initialize admin panel
-            if (window.MealMap.adminPanel && typeof window.MealMap.adminPanel.init === 'function') {
-              window.MealMap.adminPanel.init();
             }
             
             // Initialize UI manager

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,7 @@ module.exports = (env, argv) => {
   
   return {
     entry: {
-      main: './src/js/main.js',
-      admin: './src/js/admin.js'
+      main: './src/js/main.js'
     },
     output: {
       path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
## Summary
- drop admin.js entry from webpack config since file no longer exists
- remove stale admin panel feature imports to fix build

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68973681409c832397fc8a82f8c20875